### PR TITLE
Contents api

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
+var contentsRouter = require('./routes/contents');
 
 var app = express();
 
@@ -16,5 +17,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
+app.use('/contents', contentsRouter);
 
 module.exports = app;

--- a/src/routes/contents.js
+++ b/src/routes/contents.js
@@ -1,0 +1,202 @@
+const express = require('express');
+const router = express.Router();
+const mysql = require('mysql');
+const dbconfig = require('../config/database.js');
+const connection = mysql.createConnection(dbconfig);
+const bodyParser = require('body-parser');
+
+router.use(bodyParser.urlencoded({ extended: true }));
+router.use(bodyParser.json());
+
+var user_subscriptions = [];                // User Subcription
+var user_subscriptions_platform_id = [];    // User's subscribing platform_id
+var user_subscriptions_keyword = [];        // User's subscribing keyword
+var user_subscriptions_textContents = [];   // User's textcontents
+var user_subscriptions_videoContents = [];   // User's textcontents
+
+var getUserSubscriptionInformationByUserId = function (id, callback) {
+
+    var sql = 'SELECT * FROM subscriptions WHERE user_id = ' + id;
+    
+    connection.query(sql, (err, rows, fields) => {
+        if (err) return callback(err);
+        if (rows.length) {
+            for (var i = 0; i < rows.length; i++) {
+                user_subscriptions.push(rows[i]);
+            }
+        }
+        callback(null, user_subscriptions);
+    });
+}
+
+var getTextContentsByPlatformIdAndKeyWord = function (platform_id, keyword, callback){
+ 
+    var count = 0;
+
+    for(var i = 0; i < platform_id.length; i++){
+        var sql = 'SELECT * FROM textcontents WHERE platform_id = ';
+        sql += platform_id[i];
+        sql += ' AND title LIKE "%' + keyword[i] + '%"';
+
+        connection.query(sql, (err, rows, field) => {
+            if(err) {
+                console.log("ERR")
+                return callback(err);
+            }
+            else{
+                rows.forEach(element => {
+                    user_subscriptions_textContents.push(element);
+                });
+
+                if(count === platform_id.length-1){
+                    callback(null, user_subscriptions_textContents);
+                }
+                count++;
+            }
+        })
+    }
+}
+
+var getVideoContentsByPlatformIdAndKeyWord = function (platform_id, keyword, callback){
+ 
+    var count = 0;
+
+    for(var i = 0; i < platform_id.length; i++){
+        var sql = 'SELECT * FROM videocontents WHERE platform_id = ';
+        sql += platform_id[i];
+        sql += ' AND title LIKE "%' + keyword[i] + '%"';
+
+        connection.query(sql, (err, rows, field) => {
+            if(err) {
+                console.log("ERR")
+                return callback(err);
+            }
+            else{
+                rows.forEach(element => {
+                    user_subscriptions_videoContents.push(element);
+                });
+
+                if(count === platform_id.length-1){
+                    callback(null, user_subscriptions_videoContents);
+                }
+                count++;
+            }
+        })
+    }
+}
+
+var convertObjectToJson = function(object){
+    // console.log(typeof(object))              // Object(RowDataPacket)
+    var string = JSON.stringify(object);        // convert Object to Json string
+    // console.log(typeof(string))              // string
+    var json_result = JSON.parse(string);       // conver JSON string to JSON Object
+    // console.log(typeof(json_result))         // Object(JSON)
+    
+    return json_result;
+} 
+
+
+/* GET textContents array of user by user_hash */
+// 참고 : https://github.com/mysqljs/mysql/issues/1361
+router.get('/text/:id', (req, res, next) => {
+    const userId = req.params.id;
+
+    var result = false;
+
+    getUserSubscriptionInformationByUserId(userId, function (err, rows) {
+        if (err) {
+            console.log("Error while Get User Subscription Information By UserId!", err);
+        }
+        else {
+            json_result = convertObjectToJson(rows);
+            
+            for(let i = 0; i < json_result.length; i++)
+            {
+                user_subscriptions_platform_id.push(json_result[i].platform_id);
+                user_subscriptions_keyword.push(json_result[i].keyword);
+            }
+        
+            getTextContentsByPlatformIdAndKeyWord(
+                user_subscriptions_platform_id,
+                user_subscriptions_keyword,
+                function(err, rows){
+                    if(err){
+                        console.log("Error while Get Text Contents By user's platform id & user's keyword!", err);
+                    }
+                    else{
+                        result = true;
+                        res.json({
+                            result: result,
+                            rows: rows
+                        })
+                    }
+                }
+            )
+        }
+    });
+    
+    user_subscriptions = [];                    // Reset user_subscriptions
+    user_subscriptions_textContents = [];       // Reset user_subscriptions_textContents
+    user_subscriptions_keyword = [];            // Reset user_subscriptions_keyword
+    user_subscriptions_platform_id = [];        // Reset user_subscriptions_platform_id
+});
+
+/* GET videoContents array of user by user_hash */
+// 참고 : https://github.com/mysqljs/mysql/issues/1361
+router.get('/video/:id', (req, res, next) => {
+    const userId = req.params.id;
+
+    var result = false;
+
+    getUserSubscriptionInformationByUserId(userId, function (err, rows) {
+        if (err) {
+            console.log("Error while Get User Subscription Information By UserId!", err);
+        }
+        else {
+            json_result = convertObjectToJson(rows);
+            
+            for(let i = 0; i < json_result.length; i++)
+            {
+                user_subscriptions_platform_id.push(json_result[i].platform_id);
+                user_subscriptions_keyword.push(json_result[i].keyword);
+            }
+        
+            getVideoContentsByPlatformIdAndKeyWord(
+                user_subscriptions_platform_id,
+                user_subscriptions_keyword,
+                function(err, rows){
+                    if(err){
+                        console.log("Error while Get Video Contents By user's platform id & user's keyword!", err);
+                    }
+                    else{
+                        result = true;
+                        res.json({
+                            result: result,
+                            rows: rows
+                        })
+                    }
+                }
+            )
+        }
+    });
+    
+    user_subscriptions = [];                    // Reset user_subscriptions
+    user_subscriptions_videoContents = [];       // Reset user_subscriptions_textContents
+    user_subscriptions_keyword = [];            // Reset user_subscriptions_keyword
+    user_subscriptions_platform_id = [];        // Reset user_subscriptions_platform_id
+});
+
+/*-------------------------------------------------------------------------------------------
+지금 비디오랑 텍스트가 나뉘어져 있음
+근데 서로 가져오는 로직이 같음
+단지 타입이 다를뿐
+근데 그 타입도 사용하지 않음
+왜냐?
+비영상 플랫폼과 영상 플랫폼의 platform_id가 다르기 때문임
+
+1. 시간 정렬 기능 아직 안되있음
+2. response의 message는 어떤것?????
+리팩토링이 된다면 매우 좋을듯.
+--------------------------------------------------------------------------------------------*/
+
+module.exports = router;

--- a/src/routes/contents.js
+++ b/src/routes/contents.js
@@ -98,7 +98,7 @@ var convertObjectToJson = function(object){
 
 /* GET textContents array of user by user_hash */
 // 참고 : https://github.com/mysqljs/mysql/issues/1361
-router.get('/text/:id', (req, res, next) => {
+router.get('/text/users/:user_id', (req, res, next) => {
     const userId = req.params.id;
 
     var result = false;
@@ -143,7 +143,7 @@ router.get('/text/:id', (req, res, next) => {
 
 /* GET videoContents array of user by user_hash */
 // 참고 : https://github.com/mysqljs/mysql/issues/1361
-router.get('/video/:id', (req, res, next) => {
+router.get('/video/users/:user_id', (req, res, next) => {
     const userId = req.params.id;
 
     var result = false;

--- a/src/routes/contents.js
+++ b/src/routes/contents.js
@@ -103,7 +103,7 @@ var convertObjectToJson = function(object){
 /* GET textContents array of user by user_hash */
 // 참고 : https://github.com/mysqljs/mysql/issues/1361
 router.get('/text/users/:user_id', (req, res, next) => {
-    const userId = req.params.id;
+    const userId = req.params.user_id;
 
     getUserSubscriptionInformationByUserId(userId, function (err, rows) {
         if (err) {
@@ -156,7 +156,7 @@ router.get('/text/users/:user_id', (req, res, next) => {
 /* GET videoContents array of user by user_hash */
 // 참고 : https://github.com/mysqljs/mysql/issues/1361
 router.get('/video/users/:user_id', (req, res, next) => {
-    const userId = req.params.id;
+    const userId = req.params.user_id;
 
     getUserSubscriptionInformationByUserId(userId, function (err, rows) {
         if (err) {

--- a/src/routes/contents.js
+++ b/src/routes/contents.js
@@ -14,12 +14,16 @@ var user_subscriptions_keyword = [];        // User's subscribing keyword
 var user_subscriptions_textContents = [];   // User's textcontents
 var user_subscriptions_videoContents = [];   // User's textcontents
 
+var message;
+
 var getUserSubscriptionInformationByUserId = function (id, callback) {
 
     var sql = 'SELECT * FROM subscriptions WHERE user_id = ' + id;
     
     connection.query(sql, (err, rows, fields) => {
-        if (err) return callback(err);
+        if (err) {
+            return callback(err);
+        }
         if (rows.length) {
             for (var i = 0; i < rows.length; i++) {
                 user_subscriptions.push(rows[i]);
@@ -40,7 +44,6 @@ var getTextContentsByPlatformIdAndKeyWord = function (platform_id, keyword, call
 
         connection.query(sql, (err, rows, field) => {
             if(err) {
-                console.log("ERR")
                 return callback(err);
             }
             else{
@@ -68,7 +71,8 @@ var getVideoContentsByPlatformIdAndKeyWord = function (platform_id, keyword, cal
 
         connection.query(sql, (err, rows, field) => {
             if(err) {
-                console.log("ERR")
+                message = "DB has error"
+                console.log('Error while performing query.', err);
                 return callback(err);
             }
             else{
@@ -101,11 +105,14 @@ var convertObjectToJson = function(object){
 router.get('/text/users/:user_id', (req, res, next) => {
     const userId = req.params.id;
 
-    var result = false;
-
     getUserSubscriptionInformationByUserId(userId, function (err, rows) {
         if (err) {
-            console.log("Error while Get User Subscription Information By UserId!", err);
+            message = "DB has error"
+            console.log('Error while performing query.', err);
+            res.json({
+                result : message,
+                textContents : null
+            })
         }
         else {
             json_result = convertObjectToJson(rows);
@@ -121,13 +128,18 @@ router.get('/text/users/:user_id', (req, res, next) => {
                 user_subscriptions_keyword,
                 function(err, rows){
                     if(err){
-                        console.log("Error while Get Text Contents By user's platform id & user's keyword!", err);
+                        message = "DB has error"
+                        console.log('Error while performing query.', err);
+                        res.json({
+                            result : message,
+                            textContents: null
+                        })
                     }
                     else{
-                        result = true;
+                        message = "success";
                         res.json({
-                            result: result,
-                            rows: rows
+                            result: message,
+                            textContents: rows
                         })
                     }
                 }
@@ -146,11 +158,14 @@ router.get('/text/users/:user_id', (req, res, next) => {
 router.get('/video/users/:user_id', (req, res, next) => {
     const userId = req.params.id;
 
-    var result = false;
-
     getUserSubscriptionInformationByUserId(userId, function (err, rows) {
         if (err) {
-            console.log("Error while Get User Subscription Information By UserId!", err);
+            message = "DB has error"
+            console.log('Error while performing query.', err);
+            res.json({
+                result : message,
+                videoContents : null
+            })
         }
         else {
             json_result = convertObjectToJson(rows);
@@ -166,13 +181,18 @@ router.get('/video/users/:user_id', (req, res, next) => {
                 user_subscriptions_keyword,
                 function(err, rows){
                     if(err){
-                        console.log("Error while Get Video Contents By user's platform id & user's keyword!", err);
+                        message = "DB has error"
+                        console.log('Error while performing query.', err);
+                        res.json({
+                            result : message,
+                            videoContents: null
+                        })
                     }
                     else{
-                        result = true;
+                        message = "success";
                         res.json({
-                            result: result,
-                            rows: rows
+                            result: message,
+                            videoContents: rows
                         })
                     }
                 }
@@ -185,6 +205,7 @@ router.get('/video/users/:user_id', (req, res, next) => {
     user_subscriptions_keyword = [];            // Reset user_subscriptions_keyword
     user_subscriptions_platform_id = [];        // Reset user_subscriptions_platform_id
 });
+
 
 /*-------------------------------------------------------------------------------------------
 지금 비디오랑 텍스트가 나뉘어져 있음


### PR DESCRIPTION
'/contents'

1. 텍스트 컨텐츠 불러오기 API ('/contents/text/users/:user_id)
=> 유저가 구독하고 있는 비영상 컨텐츠 목록을 불러온다. 만약 유저 아이디가 존재하지 않거나 디비와 연결되지 않은 등의 이유로 정상적으로 참조가 되지 않으면 사유를 result에 적고 textContents의 밸류를 null로 리턴한다. 정상적으로 참조된 경우 result에 "success"를, textContents에 textContent 어레이를 밸류로 리턴한다.

2. 비디오 컨텐츠 불러오기 API ('/contents/video/users/:user_id)
=> 유저가 구독하고 있는 비영상 컨텐츠 목록을 불러온다. 만약 유저 아이디가 존재하지 않거나 디비와 연결되지 않은 등의 이유로 정상적으로 참조가 되지 않으면 사유를 result에 적고 videoContents의 밸류를 null로 리턴한다. 정상적으로 참조된 경우 result에 "success"를, videoContents에 videoContent 어레이를 밸류로 리턴한다.

* 현재는 db의 textcontents의 들어있는 순서대로 불러온다.